### PR TITLE
Fix donation numbers not displayed if not using debug

### DIFF
--- a/addons/sourcemod/scripting/include/blap/socket.inc
+++ b/addons/sourcemod/scripting/include/blap/socket.inc
@@ -2,8 +2,8 @@ void InitDonationSocket() {
 	#if defined NO_SOCKET
 	#if defined _DEBUG
 	LogMessage("Socket: Sockets disabled, using HTTP");
-	ScheduleDonationRequest(true);
 	#endif
+	ScheduleDonationRequest(true);
 	#else
 
 	if(gSocket[SSocket] != INVALID_HANDLE && SocketIsConnected(gSocket[SSocket])) {


### PR DESCRIPTION
Without `_DEBUG` defined, schedule donation requests never been done, displaying numbers as "??????" instead.